### PR TITLE
chore(TF-16). Added possibility to use custom version for docker image tag and deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ with:
   image_provider_fetch_url: ${{ secrets.IMAGE_PROVIDER_FETCH_URL }}
   coveo_organization_id: ${{ secrets.NEXT_PUBLIC_COVEO_ORGANIZATION_ID }}
   coveo_access_token: ${{ secrets.NEXT_PUBLIC_COVEO_ACCESS_TOKEN }}
+  version: 2.3.0
 ```
 
 **Input Parameters:**
@@ -54,6 +55,7 @@ with:
 - `image_provider_fetch_url`: URL for fetching images from the selected image provider. Optional field.
 - `coveo_organization_id`: Coveo organization ID required for coveo integration. Optional field.
 - `coveo_access_token`: Coveo organization access token required for coveo integration. Optional field.
+- `version`: Version that will be used for docker image tag. Example: 2.3.0, 3.1.0-rc.1. If not passed, github.sha will be used 
 
 ### build-middleware
 
@@ -68,6 +70,7 @@ with:
   npm_pass: ${{ secrets.NPM_PASS }}
   docker_registry_url: 'registry.vuestorefront.cloud'
   npm_registry: 'https://registrynpm.storefrontcloud.io'
+  version: 2.3.0
 ```
 
 **Input Parameters:**
@@ -80,6 +83,7 @@ with:
 - `npm_pass`: Password for the private NPM registry. Required field.
 - `docker_registry_url`: URL to the Docker image registry. Optional field. Defaults to `registry.vuestorefront.cloud`.
 - `npm_registry`: URL to the private NPM registry. Optional field. Defaults to `https://registrynpm.storefrontcloud.io`.
+- `version`: Version that will be used for docker image tag. Example: 2.3.0, 3.1.0-rc.1. If not passed, github.sha will be used 
 
 ### deploy
 
@@ -92,6 +96,7 @@ with:
   cloud_region: ${{ secrets.CLOUD_REGION }}
   docker_registry_url: 'registry.vuestorefront.cloud'
   console_api: 'https://api.platform.vuestorefront.io'
+  version: 2.3.0
 ```
 
 **Input Parameters:**
@@ -102,3 +107,4 @@ with:
 - `cloud_region`: Region where the environment is set up in the Console. Required field.
 - `docker_registry_url`: URL to the Docker image registry. Optional field. Defaults to `registry.vuestorefront.cloud`.
 - `console_api_url`: URL to the Console. Optional field. Defaults to `https://api.platform.vuestorefront.io`.
+- `version`: Docker image tag that will be deployed. Example: 2.3.0, 3.1.0-rc.1. If not passed, github.sha will be used 

--- a/build-frontend/action.yml
+++ b/build-frontend/action.yml
@@ -64,7 +64,7 @@ runs:
       with:
         node-version: 18.x
     - name: Build and publish docker image (Next.js frontend)
-      if: ${{ inputs.frontend == 'next' }}
+      if: ${{ inputs.frontend == 'next' || inputs.frontend == 'nextjs' }}
       uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: ${{ inputs.project_name }}-storefrontcloud-io/vue-storefront:${{ github.sha }}

--- a/build-frontend/action.yml
+++ b/build-frontend/action.yml
@@ -56,6 +56,9 @@ inputs:
   coveo_access_token:
     description: 'Coveo access token'
     required: false
+  version:
+    description: 'Version of the app'
+    required: false
 runs:
   using: 'composite'
   steps:
@@ -67,7 +70,7 @@ runs:
       if: ${{ inputs.frontend == 'next' || inputs.frontend == 'nextjs' }}
       uses: elgohr/Publish-Docker-Github-Action@v5
       with:
-        name: ${{ inputs.project_name }}-storefrontcloud-io/vue-storefront:${{ github.sha }}
+        name: ${{ inputs.project_name }}-storefrontcloud-io/vue-storefront:${{ inputs.version || github.sha }}
         registry: ${{ inputs.docker_registry_url }}
         username: ${{ inputs.cloud_username }}
         password: ${{ inputs.cloud_password }}
@@ -90,7 +93,7 @@ runs:
       if: ${{ inputs.frontend == 'nuxt' }}
       uses: elgohr/Publish-Docker-Github-Action@v5
       with:
-        name: ${{ inputs.project_name }}-storefrontcloud-io/vue-storefront:${{ github.sha }}
+        name: ${{ inputs.project_name }}-storefrontcloud-io/vue-storefront:${{ inputs.version || github.sha }}
         registry: ${{ inputs.docker_registry_url }}
         username: ${{ inputs.cloud_username }}
         password: ${{ inputs.cloud_password }}

--- a/build-middleware/action.yml
+++ b/build-middleware/action.yml
@@ -27,6 +27,9 @@ inputs:
     description: 'NPM registry'
     required: false
     default: 'https://registrynpm.storefrontcloud.io'
+  version:
+    description: 'Version of the app'
+    required: false
 runs:
   using: "composite"
   steps:
@@ -46,12 +49,12 @@ runs:
         registry: ${{ inputs.docker_registry_url }}
         auth: "Basic ${{ steps.base64-auth.outputs.BASIC_AUTH_TOKEN }}"
         repository: ${{ inputs.project_name }}-storefrontcloud-io/vue-storefront-middleware
-        tag: ${{ github.sha }}
+        tag: ${{ inputs.version || github.sha }}
     - name: Build and publish docker image (middleware)
       uses: elgohr/Publish-Docker-Github-Action@v5
       if: ${{ steps.check-existing-image.outputs.exists == 'false' }}
       with:
-        name: ${{ inputs.project_name }}-storefrontcloud-io/vue-storefront-middleware:${{ github.sha }}
+        name: ${{ inputs.project_name }}-storefrontcloud-io/vue-storefront-middleware:${{ inputs.version || github.sha }}
         registry: ${{ inputs.docker_registry_url }}
         username: ${{ inputs.cloud_username }}
         password: ${{ inputs.cloud_password }}

--- a/deploy/action.yml
+++ b/deploy/action.yml
@@ -21,6 +21,9 @@ inputs:
     description: 'URI for Vue Storefront Console API'
     required: false
     default: 'https://api.platform.vuestorefront.io'
+  version:
+    description: 'Version of the app'
+    required: false
 
 runs:
   using: "composite"
@@ -40,7 +43,7 @@ runs:
         url: "${{ inputs.console_api_url }}/cloud/instances/${{ inputs.project_name }}-${{ inputs.cloud_region }}-gcp-storefrontcloud-io/deploy"
         method: "PATCH"
         customHeaders: '{"Content-Type":"application/json"}'
-        data: '{ "cloudUserId":"${{ inputs.cloud_username }}", "cloudUserPassword":"${{ inputs.cloud_password }}", "dockerImageHash":"${{ github.sha }}" }'
+        data: '{ "cloudUserId":"${{ inputs.cloud_username }}", "cloudUserPassword":"${{ inputs.cloud_password }}", "dockerImageHash":"${{ inputs.version || github.sha }}" }'
         timeout: 60000
 
     - name: Deploy Middleware (${{ inputs.project_name }}.${{ inputs.cloud_region }}.gcp.storefrontcloud.io)
@@ -49,7 +52,7 @@ runs:
         url: "${{ inputs.console_api_url }}/cloud/instances/${{ inputs.project_name }}-${{ inputs.cloud_region }}-gcp-storefrontcloud-io/deploy"
         method: "PATCH"
         customHeaders: '{"Content-Type":"application/json"}'
-        data: '{ "middleware":true, "cloudUserId":"${{ inputs.cloud_username }}", "cloudUserPassword":"${{ inputs.cloud_password }}", "dockerImageHash":"${{ github.sha }}", "middlewareData":{ "path":"/api/", "port":4000, "has_base_path":false } }'
+        data: '{ "middleware":true, "cloudUserId":"${{ inputs.cloud_username }}", "cloudUserPassword":"${{ inputs.cloud_password }}", "dockerImageHash":"${{ inputs.version || github.sha }}", "middlewareData":{ "path":"/api/", "port":4000, "has_base_path":false } }'
         timeout: 60000
 
     - name: Update deployment status (success)


### PR DESCRIPTION
### 🔗 Linked issue

https://alokai.atlassian.net/browse/TF-16

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSDoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

When I worked on a POC that showed how to deploy to create/update sales demos via Github Action, I realized that I needed to specify a different version of the docker image than `github.sha`

This PR introduced a new input called `version` that allows the specification of a name for the docker tag and deployment tag. 
No breaking changes - if version is not specified, github.sha will be used as before. 

Moreover, I added a slight change in the build-frontend action that allows us to pass 'nextjs' as a frontend.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
